### PR TITLE
Não fazer bootstrap quando em fluxo oauth

### DIFF
--- a/kong/plugins/oidc/filter.lua
+++ b/kong/plugins/oidc/filter.lua
@@ -38,4 +38,8 @@ function M.isAuthBootstrapRequest(config)
   end
 end
 
+function M.isOAuthCodeRequest()
+  return string.find(ngx.var.uri,"?code=") 
+end
+
 return M

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -17,7 +17,7 @@ function OidcHandler:access(config)
 
   if filter.shouldProcessRequest(oidcConfig) then
     session.configure(config)
-    if filter.isAuthBootstrapRequest(oidcConfig) then
+    if filter.isAuthBootstrapRequest(oidcConfig) and not filter.isOAuthCodeRequest() then
       auth_bootstrap(oidcConfig)
     else
       handle(oidcConfig)


### PR DESCRIPTION
## PQ
Quando usamos a hosted ui da AWS, ele redireciona pra bootstrap com code oauth na url ex:https://services.dev.contaazul.local/auth-integration/internal/v1/boot?code=af2e673a-5fd7-4a02-b61d-772af6da57a6

Nesse caso não é necessario inicializar sessão,visto que o processo de incialização da sessão será feito pelo fluxo OIDC padrão

## OQ
Dando bypass do bootstrap quando tem code na url
