### PR TITLE
Nao fazer redirect no bootstrap

### DIFF
--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -66,7 +66,7 @@ function auth_bootstrap(oidcConfig)
   local tokens_str = ngx.req.get_headers()['x-auth-bootstrap']
   local json_tokens = cjson_s.decode(tokens_str)
   if(json_tokens) then
-    local res, err = require("resty.openidc").save_as_authenticated(oidcConfig,nil,json_tokens)
+    local res, err = require("resty.openidc").save_as_authenticated(oidcConfig,nil,json_tokens,false)
     if err then redirect_to_error(oidcConfig) end
   else
     local err = "JSON decode failed"


### PR DESCRIPTION
## PQ
Com a unificacao do bootstrap e callback de login no endpoint /auth-integration/v1/internal/boot, nao podemos fazer redirect ao fim do boostrap

## OQ
Adicionada flag no metodo save_as_authenticated, pra configurar se o redirect vai ser feito ou nao