### PR TITLE
oauth bypass on request_uri

### DIFF
--- a/kong/plugins/oidc/filter.lua
+++ b/kong/plugins/oidc/filter.lua
@@ -39,7 +39,8 @@ function M.isAuthBootstrapRequest(config)
 end
 
 function M.isOAuthCodeRequest()
-  return string.find(ngx.var.uri,"?code=") 
+  ngx.log(ngx.DEBUG, "oauth check on url: " .. ngx.var.request_uri)
+  return string.find(ngx.var.request_uri,"?code=") 
 end
 
 return M


### PR DESCRIPTION
## PQ
ngx.var.uri não continha os query params, por isso nao servia pra validar se eh fluxo de oauth code

## OQ
Alterado pra request_uri