### PR TITLE
[ARCH-847] Adicionando suporte a bypass por lista de cookies e header

### DIFF
--- a/kong/plugins/oidc/filter.lua
+++ b/kong/plugins/oidc/filter.lua
@@ -25,8 +25,36 @@ local function cookiePresent(cookie_attr)
   return false  
 end
 
+
+local function hasCookieOnList(cookie_list)
+  if cookie_list and cookie_list ~= '' and ngx.req.get_headers() then
+      local cookies = ngx.req.get_headers()['Cookie']
+      if cookies and cookies ~= '' then
+        for _, cookie in ipairs(cookie_list) do
+          local found = string.find(cookies, cookie .. "=",1,true)
+          if(found) then
+            return 
+          end
+        end
+      end
+  end
+  return false
+end
+
+local function hasHeaderOnList(header_list)
+  if header_list and header_list ~= '' and ngx.req.get_headers() then
+        for _, header in ipairs(header_list) do
+          local found = ngx.req.get_headers()[header] and ngx.req.get_headers()[header] ~= ''
+          if(found) then
+            return 
+          end
+        end
+  end
+  return false
+end
+
 function M.shouldProcessRequest(config)
-  return not (headerPresent(config.bypass_header) or cookiePresent(config.bypass_cookie)) and (not shouldIgnoreRequest(config.filters))
+  return not (headerPresent(config.bypass_header) or cookiePresent(config.bypass_cookie) or hasCookieOnList(config.bypass_cookie_list) or hasHeaderOnList(config.bypass_header_list) ) and (not shouldIgnoreRequest(config.filters))
 end
 
 function M.isAuthBootstrapRequest(config)

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -26,8 +26,13 @@ return {
     redirect_after_logout_uri = { type = "string", required = false, default = '/' },
     auth_bootstrap_path = { type = "string" , required = false},
     refresh_session_interval = { type = "number" , required = false},
+    
     bypass_header = { type = "string", required = false },
+    bypass_header_list = { type = "string", required = false },
+    
     bypass_cookie = { type = "string", required = false },
+    bypass_cookie_list = { type = "string", required = false },
+    
     filters = { type = "string" }
   }
 }

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -65,6 +65,8 @@ function M.get_options(config, ngx)
     logout_path = config.logout_path,
     bypass_header = config.bypass_header,
     bypass_cookie = config.bypass_cookie,
+    bypass_cookie_list = parseFilters(config.bypass_cookie_list),
+    bypass_header_list = parseFilters(config.bypass_header_list),
     ignore_nonce_validation = config.ignore_nonce_validation,
     redirect_after_logout_uri = config.redirect_after_logout_uri,
   }

--- a/test/unit/test_filters_advanced.lua
+++ b/test/unit/test_filters_advanced.lua
@@ -169,4 +169,72 @@ function TestFilter:testBypassBothConfiguredBothProvided()
   lu.assertFalse(filter.shouldProcessRequest(config) )
 end
 
+function TestFilter:testBypassCookieListWhenSingleCookieProvided()
+  config.bypass_cookie_list = {"Auth-Token","Other-Token"}
+  ngx.req.get_headers = function () 
+      return { Cookie = "Auth-Token=blue"} 
+  end
+  lu.assertFalse(filter.shouldProcessRequest(config) )
+end
+
+function TestFilter:testBypassCookieListWhenBothCookiesProvided()
+  config.bypass_cookie_list = {"Auth-Token","Other-Token"}
+  ngx.req.get_headers = function () 
+      return { Cookie = "Other-Token=xyz;Auth-Token=blue;"} 
+  end
+  lu.assertFalse(filter.shouldProcessRequest(config) )
+end
+
+function TestFilter:testNoBypassWithCookieList()
+  config.bypass_cookie_list = {"Auth-Token","Other-Token"}
+  ngx.req.get_headers = function () 
+      return { Cookie = "Zambas=true;"} 
+  end
+  lu.assertTrue(filter.shouldProcessRequest(config) )
+end
+
+function TestFilter:testBypassHeaderListWhenSingleHeaderProvided()
+  config.bypass_header_list = {"zambas","XAuthorization"}
+  ngx.req.get_headers = function () 
+      return { XAuthorization = 'blue'} 
+  end
+  lu.assertFalse(filter.shouldProcessRequest(config) )
+end
+
+function TestFilter:testBypassHeaderListWhenBothHeadersProvided()
+  config.bypass_header_list = {"zambas","XAuthorization"}
+  ngx.req.get_headers = function () 
+      return { XAuthorization = 'blue', zambas = "xpto"} 
+  end
+  lu.assertFalse(filter.shouldProcessRequest(config) )
+end
+
+function TestFilter:testNoBypassWithHeaderList()
+  config.bypass_header_list = {"xyz","xpto"}
+  ngx.req.get_headers = function () 
+      return { XAuthorization = 'blue'} 
+  end
+  lu.assertTrue(filter.shouldProcessRequest(config) )
+end
+
+function TestFilter:testBypassHeaderListWithNoCookieMatch()
+  config.bypass_header_list = {"xyz","xpto"}
+  config.bypass_cookie_list = {"Auth-Token","Other-Token"}
+  
+  ngx.req.get_headers = function () 
+      return { xyz = 'blue', Cookie:"zambas=true"} 
+  end
+  lu.assertFalse(filter.shouldProcessRequest(config) )
+end
+
+function TestFilter:testBypassCookieListWithNoHeaderMatch()
+  config.bypass_header_list = {"xyz","xpto"}
+  config.bypass_cookie_list = {"Auth-Token","Other-Token"}
+  
+  ngx.req.get_headers = function () 
+      return { zambas = 'blue', Cookie:"Auth-Token=123456"} 
+  end
+  lu.assertFalse(filter.shouldProcessRequest(config) )
+end
+
 lu.run()


### PR DESCRIPTION
## PQ
Explicado https://contaazul.atlassian.net/browse/ARCH-847

## OQ
Adicionada propriedade pra dar bypass na autenticação caso algum dos headers ou cookies configurados estejam na request.

Com isso, se o cliente tiver autenticado tanto no CAPRO quanto no CA+ ao mesmo tempo, vamos conseguir entender que tem tokens/headers antigos de autenticação e a nova autenticação será "ignorada"